### PR TITLE
Validate token blockchain status

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/blockchain_wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/blockchain_wallet_controller_test.exs
@@ -66,7 +66,11 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
   describe "/blockchain_wallet.deposit_to_childchain" do
     test_with_auths "deposit to childchain with the given attributes" do
       hot_wallet = BlockchainWallet.get_primary_hot_wallet(@valid_rootchain_identifier)
-      token = insert_confirmed_token("0x0000000000000000000000000000000000000000")
+
+      token =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000"
+        })
 
       adapter = BlockchainHelper.adapter()
       {:ok, _adapter_pid} = adapter.server().start_link([])
@@ -97,7 +101,10 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
     end
 
     test_with_auths "fails to deposit with a missing address" do
-      token = insert_confirmed_token("0x0000000000000000000000000000000000000000")
+      token =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000"
+        })
 
       response =
         request("/blockchain_wallet.deposit_to_childchain", %{
@@ -271,9 +278,20 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000")
-      _token_2 = insert_confirmed_token("0x0000000000000000000000000000000000000001")
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000"
+        })
+
+      _token_2 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000001"
+        })
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002"
+        })
 
       attrs = %{
         "sort_by" => "inserted_at",
@@ -303,13 +321,19 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000")
-      _token_2 = insert_confirmed_token("0x0000000000000000000000000000000000000001")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000"
+        })
+
+      _token_2 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000001"
+        })
 
       _token_3 =
-        insert(:token, %{
+        insert(:blockchain_confirmed_token, %{
           blockchain_address: "0x0000000000000000000000000000000000000002",
-          blockchain_identifier: @valid_rootchain_identifier,
           blockchain_status: Token.blockchain_status_pending()
         })
 
@@ -337,9 +361,23 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000", "tkn_1")
-      token_2 = insert_confirmed_token("0x0000000000000000000000000000000000000001", "tkn_2")
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002", "tkn_3")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          id: "tkn_1"
+        })
+
+      token_2 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000001",
+          id: "tkn_2"
+        })
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002",
+          id: "tkn_3"
+        })
 
       attrs = %{
         "sort_by" => "inserted_at",
@@ -368,9 +406,20 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000")
-      _token_2 = insert_confirmed_token("0x0000000000000000000000000000000000000001")
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000"
+        })
+
+      _token_2 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000001"
+        })
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002"
+        })
 
       attrs = %{
         "address" => blockchain_wallet.address,
@@ -400,9 +449,20 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000")
-      _token_2 = insert_confirmed_token("0x0000000000000000000000000000000000000001")
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000"
+        })
+
+      _token_2 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000001"
+        })
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002"
+        })
 
       attrs = %{
         "per_page" => 1,
@@ -435,9 +495,23 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000", "tkn_1")
-      _token_2 = insert_confirmed_token("0x0000000000000000000000000000000000000001", "tkn_2")
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002", "tkn_3")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          id: "tkn_1"
+        })
+
+      _token_2 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000001",
+          id: "tkn_2"
+        })
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002",
+          id: "tkn_3"
+        })
 
       attrs = %{
         "address" => blockchain_wallet.address,
@@ -467,9 +541,17 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000")
-      _token_2 = insert_confirmed_token(nil)
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000"
+        })
+
+      _token_2 = insert(:blockchain_confirmed_token, %{blockchain_address: nil})
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002"
+        })
 
       attrs = %{
         "address" => blockchain_wallet.address,
@@ -494,9 +576,23 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000", "tkn_1")
-      _token_2 = insert_confirmed_token("0x0000000000000000000000000000000000000001", "tkn_2")
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002", "tkn_3")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          id: "tkn_1"
+        })
+
+      _token_2 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000001",
+          id: "tkn_2"
+        })
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002",
+          id: "tkn_3"
+        })
 
       attrs = %{
         "address" => blockchain_wallet.address,
@@ -522,9 +618,19 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       blockchain_wallet =
         insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000", "tkn_1")
-      _token_2 = insert_confirmed_token(nil, "tkn_2")
-      _token_3 = insert_confirmed_token("0x0000000000000000000000000000000000000002", "tkn_3")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          id: "tkn_1"
+        })
+
+      _token_2 = insert(:blockchain_confirmed_token, %{blockchain_address: nil, id: "tkn_2"})
+
+      _token_3 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000002",
+          id: "tkn_3"
+        })
 
       attrs = %{
         "address" => blockchain_wallet.address,
@@ -549,7 +655,11 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
     test_with_auths "returns and error when given an invalid blockchain identifier" do
       insert(:blockchain_wallet, %{address: "0x0000000000000000000000000000000000000123"})
 
-      _token_1 = insert_confirmed_token("0x0000000000000000000000000000000000000000", "tkn_1")
+      _token_1 =
+        insert(:blockchain_confirmed_token, %{
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          id: "tkn_1"
+        })
 
       response =
         request("/blockchain_wallet.get_balances", %{
@@ -577,21 +687,5 @@ defmodule AdminAPI.V1.BlockchainWalletControllerTest do
       refute response["success"]
       assert response["data"]["code"] == "client:invalid_parameter"
     end
-  end
-
-  defp insert_confirmed_token(address, id \\ nil) do
-    attrs = %{
-      blockchain_address: address,
-      blockchain_identifier: @valid_rootchain_identifier,
-      blockchain_status: Token.blockchain_status_confirmed()
-    }
-
-    attrs =
-      case id do
-        nil -> attrs
-        value -> Map.put(attrs, :id, value)
-      end
-
-    insert(:token, attrs)
   end
 end

--- a/apps/ewallet/lib/ewallet/gates/mint_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/mint_gate.ex
@@ -32,10 +32,12 @@ defmodule EWallet.MintGate do
   end
 
   def mint_token(%{blockchain_address: address} = token, _) when not is_nil(address) do
-    with true <- Token.blockchain_confirmed?(token) || {:error, :token_is_not_confirmed} do
-      {:error, :invalid_parameter, "A blockchain-enabled token cannot be minted."}
-    else
-      error -> error
+    case Token.blockchain_confirmed?(token) do
+      true ->
+        {:error, :invalid_parameter, "A blockchain-enabled token cannot be minted."}
+
+      false ->
+        {:error, :token_is_not_confirmed}
     end
   end
 

--- a/apps/ewallet/lib/ewallet/gates/mint_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/mint_gate.ex
@@ -31,8 +31,12 @@ defmodule EWallet.MintGate do
     mint_token(token, attrs)
   end
 
-  def mint_token(%{blockchain_address: address}, _) when not is_nil(address) do
-    {:error, :invalid_parameter, "A blockchain-enabled token cannot be minted."}
+  def mint_token(%{blockchain_address: address} = token, _) when not is_nil(address) do
+    with true <- Token.blockchain_confirmed?(token) || {:error, :token_is_not_confirmed} do
+      {:error, :invalid_parameter, "A blockchain-enabled token cannot be minted."}
+    else
+      error -> error
+    end
   end
 
   def mint_token(token, %{"amount" => amount} = attrs)

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
@@ -35,7 +35,7 @@ defmodule EWallet.BlockchainTransactionGate do
     BlockchainHelper
   }
 
-  alias EWalletDB.{BlockchainWallet, Transaction, TransactionState}
+  alias EWalletDB.{BlockchainWallet, Token, Transaction, TransactionState}
   alias ActivityLogger.System
 
   @external_transaction Transaction.external()
@@ -231,12 +231,12 @@ defmodule EWallet.BlockchainTransactionGate do
   end
 
   defp set_token(attrs) do
-    # TODO: add check for blockchain token status
     with {:ok, %{from_token: from_token}, %{to_token: to_token}} <-
            TokenFetcher.fetch(attrs, %{}, %{}),
          true <-
            is_binary(from_token.blockchain_address) || {:error, :token_not_blockchain_enabled},
-         true <- from_token.uuid == to_token.uuid || {:error, :blockchain_exchange_not_allowed} do
+         true <- from_token.uuid == to_token.uuid || {:error, :blockchain_exchange_not_allowed},
+         true <- Token.blockchain_confirmed?(from_token) || {:error, :token_is_not_confirmed} do
       attrs
       |> Map.put("from_token_uuid", from_token.uuid)
       |> Map.put("from_token", from_token)

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -331,7 +331,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     token_is_not_confirmed: %{
       code: "token:not_confirmed",
-      description: "The token is not yet confirmed on the blockchain."
+      description: "The token is not confirmed on the blockchain."
     },
     from_token_is_disabled: %{
       code: "token:from_token_is_disabled",

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -329,6 +329,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
       code: "token:disabled",
       description: "The given token is disabled."
     },
+    token_is_not_confirmed: %{
+      code: "token:not_confirmed",
+      description: "The token is not yet confirmed on the blockchain."
+    },
     from_token_is_disabled: %{
       code: "token:from_token_is_disabled",
       description: "The given from_token_id is disabled."

--- a/apps/ewallet/test/ewallet/gates/mint_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/mint_gate_test.exs
@@ -21,12 +21,14 @@ defmodule EWallet.MintGateTest do
   alias ActivityLogger.System
 
   describe "mint_token/2" do
-    test "returns an error when minting a blockchain token" do
+    test "returns an error when minting a confirmed blockchain token" do
+      # TODO: this test should be updated when doing blockchain token minting
       {:ok, omg} =
         :token
         |> params_for(
           symbol: "OMG",
-          blockchain_address: "0x9080682a37961d3c814464e7ada1c7e1b4638a23"
+          blockchain_address: "0x9080682a37961d3c814464e7ada1c7e1b4638a23",
+          blockchain_status: Token.blockchain_status_confirmed()
         )
         |> Token.insert()
 
@@ -34,6 +36,21 @@ defmodule EWallet.MintGateTest do
       assert res == :error
       assert code == :invalid_parameter
       assert message == "A blockchain-enabled token cannot be minted."
+    end
+
+    test "returns an error when minting a pending blockchain token" do
+      {:ok, omg} =
+        :token
+        |> params_for(
+          symbol: "OMG",
+          blockchain_address: "0x9080682a37961d3c814464e7ada1c7e1b4638a23",
+          blockchain_status: Token.blockchain_status_pending()
+        )
+        |> Token.insert()
+
+      {res, code} = MintGate.mint_token(omg, %{"amount" => 100})
+      assert res == :error
+      assert code == :token_is_not_confirmed
     end
   end
 

--- a/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
@@ -24,7 +24,7 @@ defmodule EWallet.BlockchainTransactionGateTest do
     TransactionRegistry
   }
 
-  alias EWalletDB.{Account, BlockchainWallet, Transaction, TransactionState}
+  alias EWalletDB.{Account, BlockchainWallet, Transaction, TransactionState, Token}
   alias ActivityLogger.System
   alias Utils.Helpers.Crypto
   alias Ecto.UUID
@@ -36,7 +36,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000000")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       identifier = BlockchainHelper.rootchain_identifier()
       account = Account.get_master_account()
@@ -88,7 +91,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000000")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       identifier = BlockchainHelper.rootchain_identifier()
       hot_wallet = BlockchainWallet.get_primary_hot_wallet(identifier)
@@ -132,7 +138,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000000")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       rootchain_identifier = BlockchainHelper.rootchain_identifier()
       cc_identifier = BlockchainHelper.childchain_identifier()
@@ -176,7 +185,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000999")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000999",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       rootchain_identifier = BlockchainHelper.rootchain_identifier()
       cc_identifier = BlockchainHelper.childchain_identifier()
@@ -201,7 +213,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000000")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       rootchain_identifier = BlockchainHelper.rootchain_identifier()
       cc_identifier = BlockchainHelper.childchain_identifier()
@@ -225,7 +240,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000000")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       token = insert(:token)
       identifier = BlockchainHelper.rootchain_identifier()
@@ -250,7 +268,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000000")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       identifier = BlockchainHelper.rootchain_identifier()
       hot_wallet = BlockchainWallet.get_primary_hot_wallet(identifier)
@@ -279,7 +300,10 @@ defmodule EWallet.BlockchainTransactionGateTest do
       admin = insert(:admin, global_role: "super_admin")
 
       primary_blockchain_token =
-        insert(:token, blockchain_address: "0x0000000000000000000000000000000000000000")
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_confirmed()
+        )
 
       identifier = BlockchainHelper.rootchain_identifier()
       hot_wallet = BlockchainWallet.get_primary_hot_wallet(identifier)
@@ -316,6 +340,32 @@ defmodule EWallet.BlockchainTransactionGateTest do
       }
 
       assert {:error, :token_not_blockchain_enabled} ==
+               BlockchainTransactionGate.create(admin, attrs, {true, true})
+    end
+
+    test "returns an error if the token is not confirmed" do
+      admin = insert(:admin, global_role: "super_admin")
+
+      primary_blockchain_token =
+        insert(:token,
+          blockchain_address: "0x0000000000000000000000000000000000000000",
+          blockchain_status: Token.blockchain_status_pending()
+        )
+
+      identifier = BlockchainHelper.rootchain_identifier()
+      hot_wallet = BlockchainWallet.get_primary_hot_wallet(identifier)
+
+      attrs = %{
+        "idempotency_token" => UUID.generate(),
+        "from_address" => hot_wallet.address,
+        "to_address" => Crypto.fake_eth_address(),
+        "blockchain_identifier" => identifier,
+        "token_id" => primary_blockchain_token.id,
+        "amount" => 1,
+        "originator" => %System{}
+      }
+
+      assert {:error, :token_is_not_confirmed} ==
                BlockchainTransactionGate.create(admin, attrs, {true, true})
     end
   end

--- a/apps/ewallet_db/lib/ewallet_db/token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/token.ex
@@ -297,6 +297,16 @@ defmodule EWalletDB.Token do
   end
 
   @doc """
+  Returns a query of Tokens that have the given blockchain status
+  """
+  @spec query_all_by_blockchain_status(String.t(), Ecto.Queryable.t()) :: [
+          Ecto.Queryable.t()
+        ]
+  def query_all_by_blockchain_status(status, query \\ Token) do
+    where(query, [t], t.blockchain_status == ^status)
+  end
+
+  @doc """
   Returns a query of Tokens that have an id matching in the provided list
   """
   @spec query_all_by_ids([String.t()], Ecto.Queryable.t()) :: [Ecto.Queryable.t()]

--- a/apps/ewallet_db/lib/ewallet_db/token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/token.ex
@@ -400,4 +400,12 @@ defmodule EWalletDB.Token do
     |> blockchain_changeset(attrs)
     |> Repo.update_record_with_activity_log()
   end
+
+  @doc """
+  Returns a boolean indicating if the token is confirmed and ready to be used in blockchain transactions.
+  """
+  @spec blockchain_confirmed?(%Token{}) :: boolean()
+  def blockchain_confirmed?(token) do
+    token.blockchain_status == @blockchain_status_confirmed
+  end
 end

--- a/apps/ewallet_db/test/ewallet_db/token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/token_test.exs
@@ -336,6 +336,36 @@ defmodule EWalletDB.TokenTest do
     end
   end
 
+  describe "query_all_by_blockchain_status/3" do
+    test "returns a query of tokens that have a blockchain status matching in the status" do
+      {:ok, tk_1} =
+        :token
+        |> params_for(%{blockchain_status: Token.blockchain_status_confirmed()})
+        |> Token.insert()
+
+      {:ok, tk_2} =
+        :token
+        |> params_for(%{blockchain_status: Token.blockchain_status_confirmed()})
+        |> Token.insert()
+
+      {:ok, tk_3} =
+        :token
+        |> params_for(%{blockchain_status: Token.blockchain_status_pending()})
+        |> Token.insert()
+
+      token_ids =
+        Token.blockchain_status_confirmed()
+        |> Token.query_all_by_blockchain_status()
+        |> Repo.all()
+        |> Enum.map(fn t -> t.id end)
+
+      assert length(token_ids) == 2
+
+      assert Enum.member?(token_ids, tk_1.id)
+      assert Enum.member?(token_ids, tk_2.id)
+      refute Enum.member?(token_ids, tk_3.id)
+    end
+  end
 
   describe "blockchain_confirmed?/1" do
     test "returns true if the token is confirmed on the blokchcain" do

--- a/apps/ewallet_db/test/ewallet_db/token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/token_test.exs
@@ -19,6 +19,8 @@ defmodule EWalletDB.TokenTest do
   alias EWalletDB.{Token, Repo}
   alias Utils.Helpers.{Crypto, EIP55}
 
+  @valid_rootchain_identifier "ethereum"
+
   describe "Token factory" do
     test_has_valid_factory(Token)
     test_encrypted_map_field(Token, "token", :encrypted_metadata)
@@ -196,11 +198,17 @@ defmodule EWalletDB.TokenTest do
       addr_3 = Crypto.fake_eth_address()
 
       :token
-      |> params_for(%{blockchain_address: addr_1, blockchain_identifier: "ethereum"})
+      |> params_for(%{
+        blockchain_address: addr_1,
+        blockchain_identifier: @valid_rootchain_identifier
+      })
       |> Token.insert()
 
       :token
-      |> params_for(%{blockchain_address: addr_2, blockchain_identifier: "ethereum"})
+      |> params_for(%{
+        blockchain_address: addr_2,
+        blockchain_identifier: @valid_rootchain_identifier
+      })
       |> Token.insert()
 
       :token
@@ -210,7 +218,7 @@ defmodule EWalletDB.TokenTest do
       :token |> params_for() |> Token.insert()
 
       token_addresses =
-        Token.query_all_blockchain("ethereum")
+        Token.query_all_blockchain(@valid_rootchain_identifier)
         |> Repo.all()
         |> Enum.map(fn t -> t.blockchain_address end)
 
@@ -229,15 +237,24 @@ defmodule EWalletDB.TokenTest do
       addr_4 = Crypto.fake_eth_address()
 
       :token
-      |> params_for(%{blockchain_address: addr_1, blockchain_identifier: "ethereum"})
+      |> params_for(%{
+        blockchain_address: addr_1,
+        blockchain_identifier: @valid_rootchain_identifier
+      })
       |> Token.insert()
 
       :token
-      |> params_for(%{blockchain_address: addr_2, blockchain_identifier: "ethereum"})
+      |> params_for(%{
+        blockchain_address: addr_2,
+        blockchain_identifier: @valid_rootchain_identifier
+      })
       |> Token.insert()
 
       :token
-      |> params_for(%{blockchain_address: addr_3, blockchain_identifier: "ethereum"})
+      |> params_for(%{
+        blockchain_address: addr_3,
+        blockchain_identifier: @valid_rootchain_identifier
+      })
       |> Token.insert()
 
       :token
@@ -248,7 +265,7 @@ defmodule EWalletDB.TokenTest do
 
       token_addresses =
         [addr_1, addr_2]
-        |> Token.query_all_by_blockchain_addresses("ethereum")
+        |> Token.query_all_by_blockchain_addresses(@valid_rootchain_identifier)
         |> Repo.all()
         |> Enum.map(fn t -> t.blockchain_address end)
 
@@ -267,27 +284,27 @@ defmodule EWalletDB.TokenTest do
       :token
       |> params_for(%{
         blockchain_address: String.downcase(addr_1),
-        blockchain_identifier: "ethereum"
+        blockchain_identifier: @valid_rootchain_identifier
       })
       |> Token.insert()
 
       :token
       |> params_for(%{
         blockchain_address: String.downcase(addr_2),
-        blockchain_identifier: "ethereum"
+        blockchain_identifier: @valid_rootchain_identifier
       })
       |> Token.insert()
 
       :token
       |> params_for(%{
         blockchain_address: Crypto.fake_eth_address(),
-        blockchain_identifier: "ethereum"
+        blockchain_identifier: @valid_rootchain_identifier
       })
       |> Token.insert()
 
       token_addresses =
         [String.upcase(addr_1), String.upcase(addr_2)]
-        |> Token.query_all_by_blockchain_addresses("ethereum")
+        |> Token.query_all_by_blockchain_addresses(@valid_rootchain_identifier)
         |> Repo.all()
         |> Enum.map(fn t -> t.blockchain_address end)
 
@@ -316,6 +333,27 @@ defmodule EWalletDB.TokenTest do
       assert Enum.member?(token_ids, tk_1.id)
       assert Enum.member?(token_ids, tk_2.id)
       refute Enum.member?(token_ids, tk_3.id)
+    end
+  end
+
+
+  describe "blockchain_confirmed?/1" do
+    test "returns true if the token is confirmed on the blokchcain" do
+      {:ok, token} =
+        :token
+        |> params_for(%{blockchain_status: Token.blockchain_status_confirmed()})
+        |> Token.insert()
+
+      assert Token.blockchain_confirmed?(token) == true
+    end
+
+    test "returns false if the token is not confirmed on the blokchcain" do
+      {:ok, token} =
+        :token
+        |> params_for(%{blockchain_status: Token.blockchain_status_pending()})
+        |> Token.insert()
+
+      assert Token.blockchain_confirmed?(token) == false
     end
   end
 
@@ -359,7 +397,7 @@ defmodule EWalletDB.TokenTest do
         Token.set_blockchain_address(token, %{
           blockchain_address: "0x0000000000000000000000000000000000000000",
           blockchain_status: Token.blockchain_status_pending(),
-          blockchain_identifier: "ethereum",
+          blockchain_identifier: @valid_rootchain_identifier,
           originator: %System{}
         })
 
@@ -376,7 +414,7 @@ defmodule EWalletDB.TokenTest do
         Token.set_blockchain_address(token, %{
           blockchain_address: "0x0000000000000000000000000000000000000000",
           blockchain_status: "invalid status",
-          blockchain_identifier: "ethereum",
+          blockchain_identifier: @valid_rootchain_identifier,
           originator: %System{}
         })
 
@@ -393,7 +431,7 @@ defmodule EWalletDB.TokenTest do
         Token.set_blockchain_address(token, %{
           blockchain_address: "123",
           blockchain_status: Token.blockchain_status_pending(),
-          blockchain_identifier: "ethereum",
+          blockchain_identifier: @valid_rootchain_identifier,
           originator: %System{}
         })
 
@@ -428,7 +466,7 @@ defmodule EWalletDB.TokenTest do
         Token.set_blockchain_address(token, %{
           blockchain_address: address_2,
           blockchain_status: Token.blockchain_status_pending(),
-          blockchain_identifier: "ethereum",
+          blockchain_identifier: @valid_rootchain_identifier,
           originator: %System{}
         })
 
@@ -446,7 +484,7 @@ defmodule EWalletDB.TokenTest do
         Token.set_blockchain_address(token, %{
           blockchain_address: eip55_address,
           blockchain_status: Token.blockchain_status_pending(),
-          blockchain_identifier: "ethereum",
+          blockchain_identifier: @valid_rootchain_identifier,
           originator: %System{}
         })
 

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -184,6 +184,32 @@ defmodule EWalletDB.Factory do
     }
   end
 
+  def blockchain_confirmed_token_factory do
+    symbol = sequence("jon")
+
+    %Token{
+      id: "tok_" <> symbol <> "_" <> ULID.generate(),
+      symbol: symbol,
+      iso_code: sequence("JON"),
+      name: sequence("John Currency"),
+      description: sequence("Official currency of Johndoeland"),
+      short_symbol: sequence("J"),
+      subunit: "Doe",
+      subunit_to_unit: 100,
+      symbol_first: true,
+      html_entity: "&curren;",
+      iso_numeric: sequence("990"),
+      smallest_denomination: 1,
+      locked: false,
+      account: insert(:account),
+      enabled: true,
+      blockchain_address: Crypto.fake_eth_address(),
+      blockchain_status: Token.blockchain_status_confirmed(),
+      blockchain_identifier: "ethereum",
+      originator: %System{}
+    }
+  end
+
   def user_factory do
     %User{
       is_admin: false,

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -178,6 +178,8 @@ defmodule EWalletDB.Factory do
       account: insert(:account),
       enabled: true,
       blockchain_address: nil,
+      blockchain_status: nil,
+      blockchain_identifier: nil,
       originator: %System{}
     }
   end


### PR DESCRIPTION
Issue/Task Number: 1148
Closes #1148 

# Overview

This PR checks for token blockchain status before doing transaction to make sure that the token is confirmed.
Note that until https://github.com/omisego/ewallet/issues/1090 is done, tokens will remain in a `pending` status.

# Changes

- Exclude non confirmed blockchain from `blockchain_wallet.get_balance`
- Prevent `transaction.create` to succeed if the token is not confirmed
- Prevent `blockchain_wallet.deposit_to_childchain` to succeed if the token is not confirmed
- Prepare check when minting blockchain token (future PR)